### PR TITLE
Issue: Semantically Version Dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /coverage/*
 /doc/*
 .env
+*.gem
 Gemfile.lock
 .idea
 /log/*

--- a/lib/shift/circuit_breaker/version.rb
+++ b/lib/shift/circuit_breaker/version.rb
@@ -2,6 +2,6 @@
 
 module Shift
   module CircuitBreaker
-    VERSION = "0.0.1"
+    VERSION = "0.1.0"
   end
 end

--- a/shift-circuit-breaker.gemspec
+++ b/shift-circuit-breaker.gemspec
@@ -28,10 +28,10 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
 
   s.add_runtime_dependency "activesupport", "~> 5.1", ">= 5.1.4"
-  s.add_runtime_dependency "bundler", "~> 1.16"
   s.add_runtime_dependency "newrelic_rpm", "~> 4.8", ">= 4.8.0.341"
   s.add_runtime_dependency "sentry-raven", "~> 2.7", ">= 2.7.2"
 
+  s.add_development_dependency "bundler", "~> 1.16"
   s.add_development_dependency "pry", "~> 0.11.3"
   s.add_development_dependency "rake", "~> 12.3"
   s.add_development_dependency "rspec", "~> 3.7"

--- a/shift-circuit-breaker.gemspec
+++ b/shift-circuit-breaker.gemspec
@@ -27,10 +27,10 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- { test, spec, features }/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
 
-  s.add_dependency "activesupport", ">= 3.0.0"
-  s.add_dependency "bundler", ">= 1.16.1"
-  s.add_dependency "newrelic_rpm", ">= 3.1"
-  s.add_dependency "sentry-raven", ">= 1.2.3"
+  s.add_runtime_dependency "activesupport", "~> 5.1", ">= 5.1.4"
+  s.add_runtime_dependency "bundler", "~> 1.16"
+  s.add_runtime_dependency "newrelic_rpm", "~> 4.8", ">= 4.8.0.341"
+  s.add_runtime_dependency "sentry-raven", "~> 2.7", ">= 2.7.2"
 
   s.add_development_dependency "pry", "~> 0.11.3"
   s.add_development_dependency "rake", "~> 12.3"


### PR DESCRIPTION
### Overview

Related GitHub issue: https://github.com/shiftcommerce/shift-circuit-breaker/issues/3

PR addresses warnings highlighted whilst building the gem. It also bumps the gem version to minor release 0.1.0

### QA

To test, run the following rake tasks locally - 

* `./bin/setup`
* `bundle exec rspec`

### Code Review

* All included files

### Database Review

N/A

### Deployment

N/A