### PR TITLE
update newrelic_rpm version

### DIFF
--- a/lib/shift/circuit_breaker/version.rb
+++ b/lib/shift/circuit_breaker/version.rb
@@ -2,6 +2,6 @@
 
 module Shift
   module CircuitBreaker
-    VERSION = "0.2.0"
+    VERSION = "0.2.1"
   end
 end

--- a/shift-circuit-breaker.gemspec
+++ b/shift-circuit-breaker.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
 
   s.add_runtime_dependency "activesupport", "~> 5.1", ">= 5.1.4"
-  s.add_runtime_dependency "newrelic_rpm", "~> 4.8", ">= 4.8.0.341"
+  s.add_runtime_dependency "newrelic_rpm", "~> 5.3", ">= 5.3.0.346"
   s.add_runtime_dependency "sentry-raven", "~> 2.7", ">= 2.7.2"
 
   s.add_development_dependency "bundler", "~> 1.16"

--- a/shift-circuit-breaker.gemspec
+++ b/shift-circuit-breaker.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
 
   s.add_runtime_dependency "activesupport", "~> 5.1", ">= 5.1.4"
-  s.add_runtime_dependency "newrelic_rpm", "~> 5.3", ">= 5.3.0.346"
+  s.add_development_dependency "newrelic_rpm", "~> 5.3", ">= 5.3.0.346"
   s.add_runtime_dependency "sentry-raven", "~> 2.7", ">= 2.7.2"
 
   s.add_development_dependency "bundler", "~> 1.16"


### PR DESCRIPTION
### issue https://github.com/shiftcommerce/shift-circuit-breaker/issues/8

Updated `newrelic_rpm` version so the matalan front end can be updated as previously the circuit breaker was locked to a specific version.

This will help continued work on this issue https://github.com/shiftcommerce/matalan-rails-site/issues/1761#issuecomment-411675540
