### PR TITLE
Feature/Add an option to toggle logging errors functionality

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -7,5 +7,8 @@ plugins:
       - ruby
   reek:
     enabled: true
+    checks:
+      Attribute:
+        enabled: false
   rubocop:
     enabled: true

--- a/lib/shift/circuit_breaker.rb
+++ b/lib/shift/circuit_breaker.rb
@@ -27,6 +27,7 @@ module Shift
   #   CIRCUIT_BREAKER = Shift::CircuitBreaker.new(:an_identifier_for_the_circuit,
   #                                               error_threshold: 10,
   #                                               skip_duration: 60,
+  #                                               log_errors: true,
   #                                               additional_exception_classes: [Faraday::ClientError]
   #                                             )
   #

--- a/lib/shift/circuit_breaker/circuit_handler.rb
+++ b/lib/shift/circuit_breaker/circuit_handler.rb
@@ -13,7 +13,7 @@ module Shift
     # the defined skip_duration, ie. no operations are executed and the provided fallback is called.
     #
     class CircuitHandler
-      attr_accessor :name, :error_threshold, :skip_duration, :exception_classes, :enable_error_logging, :error_count
+      attr_accessor :name, :error_threshold, :skip_duration, :exception_classes, :error_logging_enabled, :error_count
       attr_accessor :last_error_time, :state, :logger, :monitor
 
       DEFAULT_EXCEPTION_CLASSES = [Net::OpenTimeout, Net::ReadTimeout, Faraday::TimeoutError, Timeout::Error].freeze
@@ -25,21 +25,21 @@ module Shift
       # @param [Integer] error_threshold   - The minimum error threshold required for the circuit to be opened/tripped
       # @param [Integer] skip_duration     - The duration in seconds the circuit should be open for before operations are allowed through/executed
       # @param [Array]   additional_exception_classes - Any additional exception classes to rescue along the DEFAULT_EXCEPTION_CLASSES
-      # @param [Boolean] enable_error_logging         - Decided whether to log errors or not. Still they will be monitored
+      # @param [Boolean] error_logging_enabled         - Decided whether to log errors or not. Still they will be monitored
       # @param [Object]  logger            - service to handle error logging
       # @param [Object]  monitor           - service to monitor metric
       def initialize(name,
                      error_threshold:,
                      skip_duration:,
                      additional_exception_classes: [],
-                     enable_error_logging: DEFAULT_ERROR_LOGGING_STATE,
+                     error_logging_enabled: DEFAULT_ERROR_LOGGING_STATE,
                      logger: Shift::CircuitBreaker::CircuitLogger.new,
                      monitor: Shift::CircuitBreaker::CircuitMonitor.new)
 
         self.name                 = name
         self.error_threshold      = error_threshold
         self.skip_duration        = skip_duration
-        self.enable_error_logging = enable_error_logging
+        self.error_logging_enabled= error_logging_enabled
         self.exception_classes    = (additional_exception_classes | DEFAULT_EXCEPTION_CLASSES)
         self.logger               = logger
         self.monitor              = monitor
@@ -109,7 +109,7 @@ module Shift
       end
 
       def log_errors(exception)
-        logger.error(circuit_name: name, state: state, error_message: exception.message) if enable_error_logging
+        logger.error(circuit_name: name, state: state, error_message: exception.message) if error_logging_enabled
       end
     end
   end

--- a/lib/shift/circuit_breaker/circuit_handler.rb
+++ b/lib/shift/circuit_breaker/circuit_handler.rb
@@ -17,6 +17,7 @@ module Shift
       attr_accessor :last_error_time, :state, :logger, :monitor
 
       DEFAULT_EXCEPTION_CLASSES = [Net::OpenTimeout, Net::ReadTimeout, Faraday::TimeoutError, Timeout::Error].freeze
+      DEFAULT_ERROR_LOGGING_STATE = true.freeze
 
       # Initializer creates an instance of the service
       #
@@ -31,7 +32,7 @@ module Shift
                      error_threshold:,
                      skip_duration:,
                      additional_exception_classes: [],
-                     enable_error_logging: true,
+                     enable_error_logging: DEFAULT_ERROR_LOGGING_STATE,
                      logger: Shift::CircuitBreaker::CircuitLogger.new,
                      monitor: Shift::CircuitBreaker::CircuitMonitor.new)
 
@@ -61,7 +62,6 @@ module Shift
       end
 
       private
-
 
       def set_state
         # The curcuit is opened/tripped if the error_threshold is met or exceeded

--- a/lib/shift/circuit_breaker/circuit_handler.rb
+++ b/lib/shift/circuit_breaker/circuit_handler.rb
@@ -15,9 +15,9 @@ module Shift
     class CircuitHandler
       attr_accessor :name, :error_threshold, :skip_duration, :exception_classes, :enable_error_logging, :error_count
       attr_accessor :last_error_time, :state, :logger, :monitor
-      
+
       DEFAULT_EXCEPTION_CLASSES = [Net::OpenTimeout, Net::ReadTimeout, Faraday::TimeoutError, Timeout::Error].freeze
-      
+
       # Initializer creates an instance of the service
       #
       # @param [Symbol]  name              - the name used to identify the circuit breaker
@@ -28,13 +28,13 @@ module Shift
       # @param [Object]  logger            - service to handle error logging
       # @param [Object]  monitor           - service to monitor metric
       def initialize(name,
-        error_threshold:,
-        skip_duration:,
-        additional_exception_classes: [],
-        enable_error_logging: true,
-        logger: Shift::CircuitBreaker::CircuitLogger.new,
-        monitor: Shift::CircuitBreaker::CircuitMonitor.new)
-        
+                     error_threshold:,
+                     skip_duration:,
+                     additional_exception_classes: [],
+                     enable_error_logging: true,
+                     logger: Shift::CircuitBreaker::CircuitLogger.new,
+                     monitor: Shift::CircuitBreaker::CircuitMonitor.new)
+
         self.name                 = name
         self.error_threshold      = error_threshold
         self.skip_duration        = skip_duration
@@ -46,7 +46,7 @@ module Shift
         self.last_error_time      = nil
         self.state                = :closed
       end
-      
+
       # Performs the given operation within the circuit
       # @param [Proc] operation - the operation to be performed
       # @param [Proc] fallback  - The result returned if the operation is not performed or raises an exception
@@ -59,10 +59,10 @@ module Shift
         end
         perform_operation(operation, fallback)
       end
-      
+
       private
-      
-      
+
+
       def set_state
         # The curcuit is opened/tripped if the error_threshold is met or exceeded
         # (error_count >= error_threshold) and the last_error_time is within
@@ -107,7 +107,7 @@ module Shift
         monitor.record_metric(name, state)
         fallback.call
       end
-      
+
       def log_errors(exception)
         logger.error(circuit_name: name, state: state, error_message: exception.message) if enable_error_logging
       end

--- a/lib/shift/circuit_breaker/circuit_handler.rb
+++ b/lib/shift/circuit_breaker/circuit_handler.rb
@@ -17,7 +17,7 @@ module Shift
       attr_accessor :last_error_time, :state, :logger, :monitor
 
       DEFAULT_EXCEPTION_CLASSES = [Net::OpenTimeout, Net::ReadTimeout, Faraday::TimeoutError, Timeout::Error].freeze
-      DEFAULT_ERROR_LOGGING_STATE = true.freeze
+      DEFAULT_ERROR_LOGGING_STATE = true
 
       # Initializer creates an instance of the service
       #

--- a/lib/shift/circuit_breaker/circuit_handler.rb
+++ b/lib/shift/circuit_breaker/circuit_handler.rb
@@ -39,7 +39,7 @@ module Shift
         self.name                 = name
         self.error_threshold      = error_threshold
         self.skip_duration        = skip_duration
-        self.error_logging_enabled= error_logging_enabled
+        self.error_logging_enabled = error_logging_enabled
         self.exception_classes    = (additional_exception_classes | DEFAULT_EXCEPTION_CLASSES)
         self.logger               = logger
         self.monitor              = monitor

--- a/lib/shift/circuit_breaker/version.rb
+++ b/lib/shift/circuit_breaker/version.rb
@@ -2,6 +2,6 @@
 
 module Shift
   module CircuitBreaker
-    VERSION = "0.2.1"
+    VERSION = "0.2.2"
   end
 end

--- a/spec/shift/circuit_breaker/circuit_handler_exception_handling_spec.rb
+++ b/spec/shift/circuit_breaker/circuit_handler_exception_handling_spec.rb
@@ -143,7 +143,7 @@ module Shift
         let(:default_skip_duration)   { 6 }
 
         context "when it is enabled" do
-          it "it should have logged errors" do
+          it "should log errors" do
             # Arrange
             operation_stub  = instance_double("Operation")
             fallback_stub   = instance_double("Fallback")
@@ -165,7 +165,7 @@ module Shift
         end
 
         context "when it is disabled" do
-          it "it should have not logged errors" do
+          it "should not log errors" do
             # Arrange
             operation_stub  = instance_double("Operation")
             fallback_stub   = instance_double("Fallback")
@@ -174,7 +174,7 @@ module Shift
             allow(operation_stub).to receive(:perform_task).and_raise(Timeout::Error, "Request Timeout")
             allow(error_logger).to receive(:error).and_return({})
             # Act
-            cb = described_class.new(:test_circuit_breaker, error_threshold: default_error_threshold, skip_duration: default_skip_duration, enable_error_logging: false, logger: error_logger)
+            cb = described_class.new(:test_circuit_breaker, error_threshold: default_error_threshold, skip_duration: default_skip_duration, error_logging_enabled: false, logger: error_logger)
             operation_result = cb.call(operation: -> { operation_stub.perform_task }, fallback: -> { fallback_stub })
 
             # Assert

--- a/spec/shift/circuit_breaker/circuit_handler_exception_handling_spec.rb
+++ b/spec/shift/circuit_breaker/circuit_handler_exception_handling_spec.rb
@@ -137,6 +137,51 @@ module Shift
           end
         end
       end
+
+      context "Error Logging" do
+        let(:default_error_threshold) { 5 }
+        let(:default_skip_duration)   { 6 }
+
+        context "when it is enabled" do
+          it "it should have logged errors" do
+            # Arrange
+            operation_stub  = instance_double("Operation")
+            fallback_stub   = instance_double("Fallback")
+            error_logger    = instance_double("Error")
+
+            allow(operation_stub).to receive(:perform_task).and_raise(Timeout::Error, "Request Timeout")
+            allow(error_logger).to receive(:error).and_return({})
+            # Act
+            cb = described_class.new(:test_circuit_breaker, error_threshold: default_error_threshold, skip_duration: default_skip_duration, logger: error_logger)
+            operation_result = cb.call(operation: -> { operation_stub.perform_task }, fallback: -> { fallback_stub })
+
+            # Assert
+            expect(operation_result).to eq(fallback_stub)
+            expect(cb.error_count).to eq(1)
+            expect(error_logger).to have_received(:error)
+          end
+        end
+
+        context "when it is disabled" do
+          it "it should have not logged errors" do
+            # Arrange
+            operation_stub  = instance_double("Operation")
+            fallback_stub   = instance_double("Fallback")
+            error_logger    = instance_double("Error")
+
+            allow(operation_stub).to receive(:perform_task).and_raise(Timeout::Error, "Request Timeout")
+            allow(error_logger).to receive(:error).and_return({})
+            # Act
+            cb = described_class.new(:test_circuit_breaker, error_threshold: default_error_threshold, skip_duration: default_skip_duration, log_errors: false, logger: error_logger)
+            operation_result = cb.call(operation: -> { operation_stub.perform_task }, fallback: -> { fallback_stub })
+
+            # Assert
+            expect(operation_result).to eq(fallback_stub)
+            expect(cb.error_count).to eq(1)
+            expect(error_logger).not_to have_received(:error)
+          end
+        end
+      end
     end
   end
 end

--- a/spec/shift/circuit_breaker/circuit_handler_exception_handling_spec.rb
+++ b/spec/shift/circuit_breaker/circuit_handler_exception_handling_spec.rb
@@ -156,9 +156,11 @@ module Shift
             operation_result = cb.call(operation: -> { operation_stub.perform_task }, fallback: -> { fallback_stub })
 
             # Assert
-            expect(operation_result).to eq(fallback_stub)
-            expect(cb.error_count).to eq(1)
-            expect(error_logger).to have_received(:error)
+            aggregate_failures do
+              expect(operation_result).to eq(fallback_stub)
+              expect(cb.error_count).to eq(1)
+              expect(error_logger).to have_received(:error)
+            end
           end
         end
 
@@ -176,9 +178,11 @@ module Shift
             operation_result = cb.call(operation: -> { operation_stub.perform_task }, fallback: -> { fallback_stub })
 
             # Assert
-            expect(operation_result).to eq(fallback_stub)
-            expect(cb.error_count).to eq(1)
-            expect(error_logger).not_to have_received(:error)
+            aggregate_failures do
+              expect(operation_result).to eq(fallback_stub)
+              expect(cb.error_count).to eq(1)
+              expect(error_logger).not_to have_received(:error)
+            end
           end
         end
       end

--- a/spec/shift/circuit_breaker/circuit_handler_exception_handling_spec.rb
+++ b/spec/shift/circuit_breaker/circuit_handler_exception_handling_spec.rb
@@ -172,7 +172,7 @@ module Shift
             allow(operation_stub).to receive(:perform_task).and_raise(Timeout::Error, "Request Timeout")
             allow(error_logger).to receive(:error).and_return({})
             # Act
-            cb = described_class.new(:test_circuit_breaker, error_threshold: default_error_threshold, skip_duration: default_skip_duration, log_errors: false, logger: error_logger)
+            cb = described_class.new(:test_circuit_breaker, error_threshold: default_error_threshold, skip_duration: default_skip_duration, enable_error_logging: false, logger: error_logger)
             operation_result = cb.call(operation: -> { operation_stub.perform_task }, fallback: -> { fallback_stub })
 
             # Assert


### PR DESCRIPTION
This PR adds a param `log_errros` to Circuit Breaker. 

With this, now we can toggle whether we want to log the errors or not.



