### PR TITLE
Issue/#18/Handle error logging for third party issues

### DIFF
--- a/lib/shift/circuit_breaker/circuit_handler.rb
+++ b/lib/shift/circuit_breaker/circuit_handler.rb
@@ -109,7 +109,13 @@ module Shift
       end
 
       def log_errors(exception)
-        logger.error(circuit_name: name, state: state, exception: exception, error_message: exception.message, remote_logging_enabled: error_logging_enabled)
+        logger.error(
+          circuit_name: name,
+          state: state,
+          exception: exception,
+          error_message: exception.message,
+          remote_logging_enabled: error_logging_enabled
+        )
       end
     end
   end

--- a/lib/shift/circuit_breaker/circuit_handler.rb
+++ b/lib/shift/circuit_breaker/circuit_handler.rb
@@ -109,7 +109,7 @@ module Shift
       end
 
       def log_errors(exception)
-        logger.error(circuit_name: name, state: state, error_message: exception.message) if error_logging_enabled
+        logger.error(circuit_name: name, state: state, exception: exception, error_message: exception.message, remote_logging_enabled: error_logging_enabled) 
       end
     end
   end

--- a/lib/shift/circuit_breaker/circuit_handler.rb
+++ b/lib/shift/circuit_breaker/circuit_handler.rb
@@ -109,7 +109,7 @@ module Shift
       end
 
       def log_errors(exception)
-        logger.error(circuit_name: name, state: state, exception: exception, error_message: exception.message, remote_logging_enabled: error_logging_enabled) 
+        logger.error(circuit_name: name, state: state, exception: exception, error_message: exception.message, remote_logging_enabled: error_logging_enabled)
       end
     end
   end

--- a/lib/shift/circuit_breaker/circuit_logger.rb
+++ b/lib/shift/circuit_breaker/circuit_logger.rb
@@ -23,7 +23,6 @@ module Shift
       def initialize(logger: ::Logger.new(STDOUT), remote_logger: Shift::CircuitBreaker::Adapters::SentryAdapter)
         self.logger = logger
         self.remote_logger = remote_logger
-        self.remote_logging_enabled = remote_logging_enabled
       end
 
       # @param [Object] context - contains :circuit_name, :state, :error_message

--- a/lib/shift/circuit_breaker/circuit_logger.rb
+++ b/lib/shift/circuit_breaker/circuit_logger.rb
@@ -30,7 +30,7 @@ module Shift
         message = (ERROR_MESSAGE % context)
         logger.error(message)
         ::NewRelic::Agent.notice_error(context[:exception], expected: true) if defined?(NewRelic)
-        remote_logger.call(message) if context[:remote_logging_enabled] && remote_logger.respond_to?(:call) 
+        remote_logger.call(message) if context[:remote_logging_enabled] && remote_logger.respond_to?(:call)
       end
     end
   end

--- a/lib/shift/circuit_breaker/version.rb
+++ b/lib/shift/circuit_breaker/version.rb
@@ -2,6 +2,6 @@
 
 module Shift
   module CircuitBreaker
-    VERSION = "0.2.2"
+    VERSION = "0.2.3"
   end
 end

--- a/spec/shift/circuit_breaker/circuit_handler_exception_handling_spec.rb
+++ b/spec/shift/circuit_breaker/circuit_handler_exception_handling_spec.rb
@@ -165,7 +165,7 @@ module Shift
         end
 
         context "when it is disabled" do
-          it "should not log errors" do
+          it "should log errors to console" do
             # Arrange
             operation_stub  = instance_double("Operation")
             fallback_stub   = instance_double("Fallback")
@@ -181,7 +181,7 @@ module Shift
             aggregate_failures do
               expect(operation_result).to eq(fallback_stub)
               expect(cb.error_count).to eq(1)
-              expect(error_logger).not_to have_received(:error)
+              expect(error_logger).to have_received(:error)
             end
           end
         end


### PR DESCRIPTION
This is to address ticket #18 

With the fix introduced in #15, errors are being stopped form reported everywhere. And also have noticed that circuit breaker errors are not logged into newrelic.

This PR allows logging into sentry only if `error_logging_enabled` is set to true, and errors will be always logged into Newrelic.

An example of error being reported after this fix:
https://rpm.newrelic.com/accounts/1488697/applications/62992650/traced_errors/fe78a41a-554f-11e9-9628-0242ac110008_0_8070
