### PR TITLE
Address the error count not reflecting issue

### DIFF
--- a/lib/shift/circuit_breaker/circuit_logger.rb
+++ b/lib/shift/circuit_breaker/circuit_logger.rb
@@ -29,7 +29,7 @@ module Shift
       def error(context)
         message = (ERROR_MESSAGE % context)
         logger.error(message)
-        ::NewRelic::Agent.notice_error(context[:exception], expected: true) if defined?(NewRelic)
+        ::NewRelic::Agent.notice_error(context[:exception]) if defined?(NewRelic)
         remote_logger.call(message) if context[:remote_logging_enabled] && remote_logger.respond_to?(:call)
       end
     end

--- a/lib/shift/circuit_breaker/version.rb
+++ b/lib/shift/circuit_breaker/version.rb
@@ -2,6 +2,6 @@
 
 module Shift
   module CircuitBreaker
-    VERSION = "0.2.3"
+    VERSION = "0.2.4"
   end
 end


### PR DESCRIPTION
With PR #19  We have got the third party error reporting working. But it was not updating the error count, this is being us due to setting it as an expected one. This PR addresses that issue.

Can see error rate reflecting here: https://rpm.newrelic.com/accounts/1488697/applications/62992650/traced_errors