### PR TITLE
Remove sentry-raven dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Example usage is as follows -
 
 ```ruby
   class MyClass
-    CIRCUIT_BREAKER = Shift::CircuitBreaker.new(:some_identifier, 
+    CIRCUIT_BREAKER = Shift::CircuitBreaker.new(name: :some_identifier, 
                                                 error_threshold: 10, 
                                                 skip_duration: 60, 
                                                 additional_exception_classes: [ 
@@ -68,7 +68,7 @@ With regards to monitoring and logging, integration with New Relic and Sentry is
 ***Note:*** both integrations can be overriden when instantiating the `Shift::CircuitMonitor` and `Shift::CircuitLogger` services, eg.
 
 ```ruby
-  CIRCUIT_BREAKER = Shift::CircuitBreaker.new(:some_identifier, 
+  CIRCUIT_BREAKER = Shift::CircuitBreaker.new(name: :some_identifier, 
                                               error_threshold: 10, 
                                               skip_duration: 60, 
                                               logger: Shift::CircuitBreaker::CircuitLogger.new(remote_logger: CUSTOM_LOGGER),

--- a/lib/shift/circuit_breaker.rb
+++ b/lib/shift/circuit_breaker.rb
@@ -24,7 +24,7 @@ module Shift
   # ==== Example Usage:
   #
   # class MyClass
-  #   CIRCUIT_BREAKER = Shift::CircuitBreaker.new(:an_identifier_for_the_circuit,
+  #   CIRCUIT_BREAKER = Shift::CircuitBreaker.new(name: :an_identifier_for_the_circuit,
   #                                               error_threshold: 10,
   #                                               skip_duration: 60,
   #                                               log_errors: true,
@@ -39,8 +39,8 @@ module Shift
   #
   module CircuitBreaker
     class << self
-      def new(*args)
-        Shift::CircuitBreaker::CircuitHandler.new(*args)
+      def new(**args)
+        Shift::CircuitBreaker::CircuitHandler.new(**args)
       end
 
       def config

--- a/lib/shift/circuit_breaker.rb
+++ b/lib/shift/circuit_breaker.rb
@@ -6,7 +6,7 @@ require "active_support/core_ext/string/inflections"
 require "faraday"
 require "logger"
 require "net/protocol"
-require "sentry-raven"
+require "sentry-ruby"
 require "singleton"
 require "timeout"
 

--- a/lib/shift/circuit_breaker/adapters/sentry_adapter.rb
+++ b/lib/shift/circuit_breaker/adapters/sentry_adapter.rb
@@ -5,7 +5,7 @@ module Shift
     module Adapters
       class SentryAdapter < BaseAdapter
         def self.call(message)
-          ::Raven.capture_exception(message) if defined?(Raven)
+          ::Sentry.capture_exception(message) if defined?(Sentry)
         end
       end
     end

--- a/lib/shift/circuit_breaker/circuit_handler.rb
+++ b/lib/shift/circuit_breaker/circuit_handler.rb
@@ -28,7 +28,7 @@ module Shift
       # @param [Boolean] error_logging_enabled         - Decided whether to log errors or not. Still they will be monitored
       # @param [Object]  logger            - service to handle error logging
       # @param [Object]  monitor           - service to monitor metric
-      def initialize(name,
+      def initialize(name:,
         error_threshold:,
         skip_duration:,
         additional_exception_classes: [],

--- a/lib/shift/circuit_breaker/config.rb
+++ b/lib/shift/circuit_breaker/config.rb
@@ -33,7 +33,7 @@ module Shift
         if sentry_dsn
           Sentry.init do |config|
             config.dsn = sentry_dsn
-            config.environments = sentry_environments if sentry_environments.present?
+            config.enabled_environments = sentry_environments if sentry_environments.present?
           end
         end
       end

--- a/lib/shift/circuit_breaker/config.rb
+++ b/lib/shift/circuit_breaker/config.rb
@@ -31,7 +31,7 @@ module Shift
 
       def initialize_sentry
         if sentry_dsn
-          Raven.configure do |config|
+          Sentry.init do |config|
             config.dsn = sentry_dsn
             config.environments = sentry_environments if sentry_environments.present?
           end

--- a/lib/shift/circuit_breaker/version.rb
+++ b/lib/shift/circuit_breaker/version.rb
@@ -2,6 +2,6 @@
 
 module Shift
   module CircuitBreaker
-    VERSION = "0.3.0"
+    VERSION = "1.0.0"
   end
 end

--- a/lib/shift/circuit_breaker/version.rb
+++ b/lib/shift/circuit_breaker/version.rb
@@ -2,6 +2,6 @@
 
 module Shift
   module CircuitBreaker
-    VERSION = "0.2.5"
+    VERSION = "0.3.0"
   end
 end

--- a/shift-circuit-breaker.gemspec
+++ b/shift-circuit-breaker.gemspec
@@ -25,9 +25,10 @@ Gem::Specification.new do |s|
   s.test_files = `git ls-files -- { test, spec, features }/*`.split("\n")
   s.executables = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
 
-  s.add_runtime_dependency "activesupport"
-  s.add_development_dependency "newrelic_rpm", "~> 5.3", ">= 5.3.0.346"
-  s.add_development_dependency "sentry-ruby", "~> 5.1"
+  s.add_runtime_dependency "activesupport", "~> 6.1"
+  s.add_runtime_dependency "faraday"
+  s.add_runtime_dependency "newrelic_rpm", "~> 5.3", ">= 5.3.0.346"
+  s.add_runtime_dependency "sentry-ruby", "~> 5.1"
 
   s.add_development_dependency "bundler"
   s.add_development_dependency "pry", "~> 0.11.3"

--- a/shift-circuit-breaker.gemspec
+++ b/shift-circuit-breaker.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency "activesupport"
   s.add_development_dependency "newrelic_rpm", "~> 5.3", ">= 5.3.0.346"
-  s.add_development_dependency "sentry-raven", "~> 2.7", ">= 2.7.2"
+  s.add_development_dependency "sentry-ruby", "~> 5.1"
 
   s.add_development_dependency "bundler"
   s.add_development_dependency "pry", "~> 0.11.3"

--- a/shift-circuit-breaker.gemspec
+++ b/shift-circuit-breaker.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/shiftcommerce/shift-circuit-breaker"
   s.authors = ["Mufudzi Masaire"]
   s.email = "mufudzi.masaire@shiftcommerce.com"
-  s.date = Time.now.strftime("%Y-%m-%d")
   s.license = "MIT"
 
   s.required_ruby_version = ">= 2.3.0"

--- a/spec/shift/adapters/sentry_adapter_spec.rb
+++ b/spec/shift/adapters/sentry_adapter_spec.rb
@@ -28,13 +28,13 @@ module Shift
             # Arrange
             message = "some exception"
 
-            allow(::Raven).to receive(:capture_exception)
+            allow(::Sentry).to receive(:capture_exception)
 
             # Act
             described_class.call(message)
 
             # Assert
-            expect(::Raven).to have_received(:capture_exception).with(message).once
+            expect(::Sentry).to have_received(:capture_exception).with(message).once
           end
         end
       end

--- a/spec/shift/circuit_breaker/circuit_handler_exception_handling_spec.rb
+++ b/spec/shift/circuit_breaker/circuit_handler_exception_handling_spec.rb
@@ -22,7 +22,7 @@ module Shift
             allow(operation_stub).to receive(:perform_task).and_raise(Timeout::Error, "Request Timeout")
 
             # Act
-            cb = described_class.new(:test_circuit_breaker, error_threshold: default_error_threshold, skip_duration: default_skip_duration)
+            cb = described_class.new(name: :test_circuit_breaker, error_threshold: default_error_threshold, skip_duration: default_skip_duration)
             operation_result = cb.call(operation: -> { operation_stub.perform_task }, fallback: -> { fallback_stub })
 
             # Assert
@@ -43,7 +43,7 @@ module Shift
             allow(operation_3_stub).to receive(:perform_task).and_raise(Timeout::Error, "Request Timeout")
 
             # Act & Assert
-            cb = described_class.new(:test_circuit_breaker, error_threshold: 2, skip_duration: default_skip_duration)
+            cb = described_class.new(name: :test_circuit_breaker, error_threshold: 2, skip_duration: default_skip_duration)
 
             # The first operation will fail with Timeout::Error, resulting in the exception being caught and
             # the fallback being returned as the operation result. The error_count is incremented to 1.
@@ -97,7 +97,7 @@ module Shift
             allow(operation_3_stub).to receive(:perform_task).and_return(expected_result_stub)
 
             # Act & Assert
-            cb = described_class.new(:test_circuit_breaker, error_threshold: 2, skip_duration: 10)
+            cb = described_class.new(name: :test_circuit_breaker, error_threshold: 2, skip_duration: 10)
 
             # The first operation will fail with Timeout::Error, resulting in the exception being caught and
             # the fallback being returned as the operation result. The error_count is incremented to 1.
@@ -152,7 +152,7 @@ module Shift
             allow(operation_stub).to receive(:perform_task).and_raise(Timeout::Error, "Request Timeout")
             allow(error_logger).to receive(:error).and_return({})
             # Act
-            cb = described_class.new(:test_circuit_breaker, error_threshold: default_error_threshold, skip_duration: default_skip_duration, logger: error_logger)
+            cb = described_class.new(name: :test_circuit_breaker, error_threshold: default_error_threshold, skip_duration: default_skip_duration, logger: error_logger)
             operation_result = cb.call(operation: -> { operation_stub.perform_task }, fallback: -> { fallback_stub })
 
             # Assert
@@ -174,7 +174,7 @@ module Shift
             allow(operation_stub).to receive(:perform_task).and_raise(Timeout::Error, "Request Timeout")
             allow(error_logger).to receive(:error).and_return({})
             # Act
-            cb = described_class.new(:test_circuit_breaker, error_threshold: default_error_threshold, skip_duration: default_skip_duration, error_logging_enabled: false, logger: error_logger)
+            cb = described_class.new(name: :test_circuit_breaker, error_threshold: default_error_threshold, skip_duration: default_skip_duration, error_logging_enabled: false, logger: error_logger)
             operation_result = cb.call(operation: -> { operation_stub.perform_task }, fallback: -> { fallback_stub })
 
             # Assert

--- a/spec/shift/circuit_breaker/circuit_handler_monitoring_spec.rb
+++ b/spec/shift/circuit_breaker/circuit_handler_monitoring_spec.rb
@@ -25,7 +25,7 @@ module Shift
             allow(operation_stub).to receive(:perform_task).and_return(expected_result_stub)
 
             # Act
-            cb = described_class.new(:test_circuit_breaker,
+            cb = described_class.new(name: :test_circuit_breaker,
               error_threshold: default_skip_duration,
               skip_duration: default_skip_duration,
               monitor: monitor_stub)
@@ -53,7 +53,7 @@ module Shift
             allow(operation_stub).to receive(:perform_task).and_raise(Timeout::Error, "Request Timeout")
 
             # Act
-            cb = described_class.new(:test_circuit_breaker, error_threshold: 1, skip_duration: default_skip_duration, monitor: monitor_stub)
+            cb = described_class.new(name: :test_circuit_breaker, error_threshold: 1, skip_duration: default_skip_duration, monitor: monitor_stub)
 
             # Assert
             aggregate_failures do

--- a/spec/shift/circuit_breaker/circuit_handler_spec.rb
+++ b/spec/shift/circuit_breaker/circuit_handler_spec.rb
@@ -22,7 +22,7 @@ module Shift
           allow(operation_stub).to receive(:perform_task).and_return(expected_result_stub)
 
           # Act
-          cb = described_class.new(:test_circuit_breaker, error_threshold: default_error_threshold, skip_duration: default_skip_duration)
+          cb = described_class.new(name: :test_circuit_breaker, error_threshold: default_error_threshold, skip_duration: default_skip_duration)
           operation_result = cb.call(operation: -> { operation_stub.perform_task }, fallback: -> { fallback_stub })
 
           # Assert
@@ -43,7 +43,7 @@ module Shift
           allow(operation_stub).to receive(:perform_task).and_raise(Faraday::ClientError, "client error")
 
           # Act
-          cb = described_class.new(:test_circuit_breaker,
+          cb = described_class.new(name: :test_circuit_breaker,
             error_threshold: default_error_threshold,
             skip_duration: default_skip_duration,
             additional_exception_classes: additional_exception_classes)
@@ -63,14 +63,14 @@ module Shift
           context "when no error_threshold is provided" do
             it "raises an ArgumentError" do
               # Act & Assert
-              expect { described_class.new(:test_circuit_breaker, skip_duration: default_skip_duration) }.to raise_error(ArgumentError)
+              expect { described_class.new(name: :test_circuit_breaker, skip_duration: default_skip_duration) }.to raise_error(ArgumentError)
             end
           end
 
           context "when no skip_duration is provided" do
             it "raises an ArgumentError" do
               # Act & Assert
-              expect { described_class.new(:test_circuit_breaker, error_threshold: default_skip_duration) }.to raise_error(ArgumentError)
+              expect { described_class.new(name: :test_circuit_breaker, error_threshold: default_skip_duration) }.to raise_error(ArgumentError)
             end
           end
         end
@@ -85,7 +85,7 @@ module Shift
               fallback_stub = instance_double("Fallback")
 
               # Act
-              cb = described_class.new(:test_circuit_breaker, error_threshold: default_error_threshold, skip_duration: default_skip_duration)
+              cb = described_class.new(name: :test_circuit_breaker, error_threshold: default_error_threshold, skip_duration: default_skip_duration)
 
               # Assert
               expect { cb.call(fallback: -> { fallback_stub }) }.to raise_error(ArgumentError)
@@ -98,7 +98,7 @@ module Shift
               operation_stub = instance_double("Operation")
 
               # Act
-              cb = described_class.new(:test_circuit_breaker, error_threshold: default_error_threshold, skip_duration: default_skip_duration)
+              cb = described_class.new(name: :test_circuit_breaker, error_threshold: default_error_threshold, skip_duration: default_skip_duration)
 
               # Act & Assert
               expect { cb.call(operation: -> { operation_stub }) }.to raise_error(ArgumentError)
@@ -111,7 +111,7 @@ module Shift
               fallback_stub = instance_double("Fallback")
 
               # Act
-              cb = described_class.new(:test_circuit_breaker, error_threshold: default_error_threshold, skip_duration: default_skip_duration)
+              cb = described_class.new(name: :test_circuit_breaker, error_threshold: default_error_threshold, skip_duration: default_skip_duration)
 
               # Assert
               expect { cb.call(operation: nil, fallback: -> { fallback_stub }) }.to raise_error(ArgumentError)
@@ -124,7 +124,7 @@ module Shift
               operation_stub = instance_double("Operation")
 
               # Act
-              cb = described_class.new(:test_circuit_breaker, error_threshold: default_error_threshold, skip_duration: default_skip_duration)
+              cb = described_class.new(name: :test_circuit_breaker, error_threshold: default_error_threshold, skip_duration: default_skip_duration)
 
               # Assert
               expect { cb.call(operation: -> { operation_stub }, fallback: nil) }.to raise_error(ArgumentError)
@@ -138,7 +138,7 @@ module Shift
               fallback_stub = instance_double("Fallback")
 
               # Act
-              cb = described_class.new(:test_circuit_breaker, error_threshold: default_error_threshold, skip_duration: default_skip_duration)
+              cb = described_class.new(name: :test_circuit_breaker, error_threshold: default_error_threshold, skip_duration: default_skip_duration)
 
               # Assert
               expect { cb.call(operation: operation_stub, fallback: -> { fallback_stub }) }.to raise_error(ArgumentError)
@@ -152,7 +152,7 @@ module Shift
               fallback_stub = instance_double("Fallback")
 
               # Act
-              cb = described_class.new(:test_circuit_breaker, error_threshold: default_error_threshold, skip_duration: default_skip_duration)
+              cb = described_class.new(name: :test_circuit_breaker, error_threshold: default_error_threshold, skip_duration: default_skip_duration)
 
               # Assert
               expect { cb.call(operation: -> { operation_stub }, fallback: fallback_stub) }.to raise_error(ArgumentError)

--- a/spec/shift/circuit_breaker_spec.rb
+++ b/spec/shift/circuit_breaker_spec.rb
@@ -47,7 +47,7 @@ module Shift
         monitor_stub = instance_double("CustomMonitor")
 
         # Act
-        cb_instance = Shift::CircuitBreaker.new(cb_name,
+        cb_instance = Shift::CircuitBreaker.new(name: cb_name,
           error_threshold: error_threshold,
           skip_duration: skip_duration,
           additional_exception_classes: additional_exception_classes,


### PR DESCRIPTION
### The Issue

Related GitHub issue: #https://github.com/shiftcommerce/shift-platform/issues/10069

Sentry-raven has entered maintenance mode, which means it won't receive any new feature supports or aggressive bug fixes. Therefore we are required to upgrade to the new Sentry SDK Sentry-ruby. 

### The Solution

- Remove Sentry-raven dependency from shift-circuit-breaker. 

### Acceptance Criteria

 - [ ] Sentry-ruby is used  instead of sentry-raven
