### PR TITLE
Add instrumentation for errors

### DIFF
--- a/lib/shift/circuit_breaker/circuit_handler.rb
+++ b/lib/shift/circuit_breaker/circuit_handler.rb
@@ -110,9 +110,7 @@ module Shift
         set_state
         log_errors(exception)
         # Increments exceptions; useful for alerting
-        monitor.record_exception(name)
-        # Increments total calls with current state e.g. open/closed
-        monitor.record_metric(name, state)
+        monitor.record_exception(name, "errored")
         fallback.call
       end
 

--- a/lib/shift/circuit_breaker/circuit_handler.rb
+++ b/lib/shift/circuit_breaker/circuit_handler.rb
@@ -109,6 +109,9 @@ module Shift
         record_error
         set_state
         log_errors(exception)
+        # Increments exceptions; useful for alerting
+        monitor.record_exception(name)
+        # Increments total calls with current state e.g. open/closed
         monitor.record_metric(name, state)
         fallback.call
       end

--- a/lib/shift/circuit_breaker/circuit_monitor.rb
+++ b/lib/shift/circuit_breaker/circuit_monitor.rb
@@ -22,10 +22,21 @@ module Shift
         logger.info("* #{metric} *")
       end
 
+      # @param [String] name - The circuit name
+      def record_exception(name)
+        metric = formatted_metric(name)
+        monitor.call(metric) if monitor.respond_to?(:call)
+        logger.info("* #{metric} *")
+      end
+
       private
 
-      def formatted_metric(name, state)
-        "Custom/#{name.to_s.classify}CircuitBreaker/#{state.to_s.classify}"
+      def formatted_metric(name, state = nil)
+        if state
+          "Custom/#{name.to_s.classify}CircuitBreaker/#{state.to_s.classify}"
+        else
+          "Custom/#{name.to_s.classify}CircuitBreaker/errors"
+        end
       end
     end
   end

--- a/lib/shift/circuit_breaker/circuit_monitor.rb
+++ b/lib/shift/circuit_breaker/circuit_monitor.rb
@@ -29,10 +29,8 @@ module Shift
 
       private
 
-      def formatted_metric(name, state = nil)
-        if state
-          "Custom/#{name.to_s.classify}CircuitBreaker/#{state.to_s.classify}"
-        end
+      def formatted_metric(name, state)
+        "Custom/#{name.to_s.classify}CircuitBreaker/#{state.to_s.classify}"
       end
     end
   end

--- a/lib/shift/circuit_breaker/circuit_monitor.rb
+++ b/lib/shift/circuit_breaker/circuit_monitor.rb
@@ -23,10 +23,8 @@ module Shift
       end
 
       # @param [String] name - The circuit name
-      def record_exception(name)
-        metric = formatted_metric(name)
-        monitor.call(metric) if monitor.respond_to?(:call)
-        logger.info("* #{metric} *")
+      def record_exception(name, state)
+        record_metric(name, state)
       end
 
       private
@@ -34,8 +32,6 @@ module Shift
       def formatted_metric(name, state = nil)
         if state
           "Custom/#{name.to_s.classify}CircuitBreaker/#{state.to_s.classify}"
-        else
-          "Custom/#{name.to_s.classify}CircuitBreaker/errors"
         end
       end
     end

--- a/lib/shift/circuit_breaker/circuit_monitor.rb
+++ b/lib/shift/circuit_breaker/circuit_monitor.rb
@@ -23,6 +23,7 @@ module Shift
       end
 
       # @param [String] name - The circuit name
+      # @param [String] state - error
       def record_exception(name, state)
         record_metric(name, state)
       end

--- a/lib/shift/circuit_breaker/version.rb
+++ b/lib/shift/circuit_breaker/version.rb
@@ -2,6 +2,6 @@
 
 module Shift
   module CircuitBreaker
-    VERSION = "1.0.1"
+    VERSION = "1.0.2"
   end
 end

--- a/spec/shift/circuit_breaker/circuit_handler_monitoring_spec.rb
+++ b/spec/shift/circuit_breaker/circuit_handler_monitoring_spec.rb
@@ -50,7 +50,6 @@ module Shift
             fallback_stub = instance_double("Fallback")
 
             allow(monitor_stub).to receive(:record_exception)
-            allow(monitor_stub).to receive(:record_metric)
             allow(operation_stub).to receive(:perform_task).and_raise(Timeout::Error, "Request Timeout")
 
             # Act
@@ -63,7 +62,6 @@ module Shift
               operation_result = cb.call(operation: -> { operation_stub.perform_task }, fallback: -> { fallback_stub })
 
               expect(monitor_stub).to have_received(:record_exception)
-              expect(monitor_stub).to have_received(:record_metric)
               expect(operation_result).to eq(fallback_stub)
             end
           end

--- a/spec/shift/circuit_breaker/circuit_handler_monitoring_spec.rb
+++ b/spec/shift/circuit_breaker/circuit_handler_monitoring_spec.rb
@@ -49,6 +49,7 @@ module Shift
             operation_stub = instance_double("Operation")
             fallback_stub = instance_double("Fallback")
 
+            allow(monitor_stub).to receive(:record_exception)
             allow(monitor_stub).to receive(:record_metric)
             allow(operation_stub).to receive(:perform_task).and_raise(Timeout::Error, "Request Timeout")
 
@@ -61,6 +62,7 @@ module Shift
 
               operation_result = cb.call(operation: -> { operation_stub.perform_task }, fallback: -> { fallback_stub })
 
+              expect(monitor_stub).to have_received(:record_exception)
               expect(monitor_stub).to have_received(:record_metric)
               expect(operation_result).to eq(fallback_stub)
             end

--- a/spec/shift/circuit_breaker/circuit_handler_spec.rb
+++ b/spec/shift/circuit_breaker/circuit_handler_spec.rb
@@ -71,7 +71,7 @@ module Shift
             error_threshold: default_error_threshold,
             skip_duration: default_skip_duration,
             additional_exception_classes: additional_exception_classes,
-            monitor: monitor,
+            monitor: monitor
           )
 
           operation_result = cb.call(operation: -> { operation_stub.perform_task }, fallback: -> { fallback_stub })

--- a/spec/shift/circuit_breaker/circuit_handler_spec.rb
+++ b/spec/shift/circuit_breaker/circuit_handler_spec.rb
@@ -63,7 +63,6 @@ module Shift
 
           allow(operation_stub).to receive(:perform_task).and_raise(Faraday::ClientError, "client error")
           allow(monitor).to receive(:record_exception)
-          allow(monitor).to receive(:record_metric)
 
           # Act
           cb = described_class.new(

--- a/spec/shift/circuit_breaker/circuit_handler_spec.rb
+++ b/spec/shift/circuit_breaker/circuit_handler_spec.rb
@@ -53,6 +53,35 @@ module Shift
           # Assert
           expect(operation_result).to eq(fallback_stub)
         end
+
+        it "instruments the exception and returns the fallback" do
+          # Arrange
+          operation_stub = instance_double("Operation")
+          fallback_stub = instance_double("Fallback")
+          monitor = instance_double("monitoring")
+          additional_exception_classes = [Faraday::ClientError]
+
+          allow(operation_stub).to receive(:perform_task).and_raise(Faraday::ClientError, "client error")
+          allow(monitor).to receive(:record_exception)
+          allow(monitor).to receive(:record_metric)
+
+          # Act
+          cb = described_class.new(
+            name: :test_circuit_breaker,
+            error_threshold: default_error_threshold,
+            skip_duration: default_skip_duration,
+            additional_exception_classes: additional_exception_classes,
+            monitor: monitor,
+          )
+
+          operation_result = cb.call(operation: -> { operation_stub.perform_task }, fallback: -> { fallback_stub })
+
+          # Assert
+          aggregate_failures do
+            expect(monitor).to have_received(:record_exception)
+            expect(operation_result).to eq(fallback_stub)
+          end
+        end
       end
 
       context "Invalid Arguments" do

--- a/spec/shift/circuit_breaker/circuit_monitor_spec.rb
+++ b/spec/shift/circuit_breaker/circuit_monitor_spec.rb
@@ -52,13 +52,13 @@ module Shift
         it "logs the metric information for an exception" do
           # Arrange
           circuit_breaker_name = :test_circuit_breaker
-          metric = "Custom/#{circuit_breaker_name.to_s.classify}CircuitBreaker/errors"
+          metric = "Custom/#{circuit_breaker_name.to_s.classify}CircuitBreaker/Error"
           metric_monitor = Shift::CircuitBreaker::Adapters::NewRelicAdapter
           circuit_monitor = described_class.new(monitor: metric_monitor)
           allow(metric_monitor).to receive(:call)
 
           # Act
-          circuit_monitor.record_exception(circuit_breaker_name)
+          circuit_monitor.record_exception(circuit_breaker_name, "errors")
 
           # Assert
           expect(metric_monitor).to have_received(:call).with(metric)

--- a/spec/shift/circuit_breaker/circuit_monitor_spec.rb
+++ b/spec/shift/circuit_breaker/circuit_monitor_spec.rb
@@ -47,6 +47,23 @@ module Shift
           end
         end
       end
+
+      context "#record_exception" do
+        it "logs the metric information for an exception" do
+          # Arrange
+          circuit_breaker_name = :test_circuit_breaker
+          metric = "Custom/#{circuit_breaker_name.to_s.classify}CircuitBreaker/errors"
+          metric_monitor = Shift::CircuitBreaker::Adapters::NewRelicAdapter
+          circuit_monitor = described_class.new(monitor: metric_monitor)
+          allow(metric_monitor).to receive(:call)
+
+          # Act
+          circuit_monitor.record_exception(circuit_breaker_name)
+
+          # Assert
+          expect(metric_monitor).to have_received(:call).with(metric)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This PR adds instrumentation for errors in newrelic. This can be used for adding alerting and notifications if the number of errors are high. 