### PR TITLE
Loosen gemspec deps

### DIFF
--- a/lib/shift/circuit_breaker/version.rb
+++ b/lib/shift/circuit_breaker/version.rb
@@ -2,6 +2,6 @@
 
 module Shift
   module CircuitBreaker
-    VERSION = "1.0.2"
+    VERSION = "1.0.3"
   end
 end

--- a/shift-circuit-breaker.gemspec
+++ b/shift-circuit-breaker.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.test_files = `git ls-files -- { test, spec, features }/*`.split("\n")
   s.executables = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
 
-  s.add_runtime_dependency "activesupport", "< 7.0"
+  s.add_runtime_dependency "activesupport"
   s.add_runtime_dependency "faraday"
   s.add_runtime_dependency "newrelic_rpm"
   s.add_runtime_dependency "sentry-ruby"


### PR DESCRIPTION
### The Issue

- Related Github Issue: https://github.com/shiftcommerce/shift-platform/issues/10479
- When attempting to run `bundle update rails` in SHIFT Platform I am hitting a version mismatch for `activesupport`:

<img width="546" alt="Screenshot 2022-07-20 at 14 20 06" src="https://user-images.githubusercontent.com/25207988/179992373-e541e147-e901-4089-b607-55f88ef3d942.png">

### The Solution

After looking through some previous [PRs](https://github.com/shiftcommerce/shift-circuit-breaker/pull/26) it looks like we need to loosen the gemspec dependency versions. This PR allows any version of `activesupport`.